### PR TITLE
Support heroku workers for compile stage

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ if [ -f Procfile ]
 then
   SCRIPT_DIR=$(cd $(dirname $0); pwd)
   source $SCRIPT_DIR/get_cache_command.sh
-  COMMAND=$(cat Procfile | grep '^web:')
+  COMMAND=$(cat Procfile | grep -E '^(web|worker):')
   if [ -n "$COMMAND" ]
   then
     CACHE_COMMAND=$(get_cache_command "$COMMAND")


### PR DESCRIPTION
While worker (not web) is used in Procfile, it fails for me. This commit fixes this problem and may be useful for others.