### PR TITLE
Provide deno to subsequent buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,6 +32,11 @@ mkdir -p $(dirname $PROFILE_PATH)
 echo 'export PATH="$HOME/.heroku/bin:$PATH"' >> $PROFILE_PATH
 echo 'export DENO_DIR="$HOME/.heroku/cache"' >> $PROFILE_PATH
 
+# Provide deno to subsequent buildpacks:
+# https://devcenter.heroku.com/articles/buildpack-api#composing-multiple-buildpacks
+BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
+echo "export PATH=\"$BIN_DIR:\$PATH"\" > "$BP_DIR/export"
+
 set +e
 
 # download dependencies


### PR DESCRIPTION
Thanks for your effort on this buildpack:

It saved me a ton of time and helped me understand better how buildpacks work!

I'm developing [Hotdocs Rails](https://hotdocsrails.com/), which needs `deno` + `ruby`. Without this change, I can use `deno` *after* the `ruby` app is deployed, but `deno` is not available during compilation.

I cannot use `heroku_build.ts` because I shell out to `deno` during compilation from a [ruby file](https://github.com/3v0k4/hotdocs/blob/0dab6c8aae3e10b8cee0f2a2445a85e683559410/lib/hotdocs/markdown.rb#L18).